### PR TITLE
Update TimeBasedAvroWriterPartitioner

### DIFF
--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitioner.java
@@ -17,34 +17,48 @@
 
 package org.apache.gobblin.writer.partitioner;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.apache.avro.generic.GenericRecord;
-
-import com.google.common.base.Optional;
-
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.util.AvroUtils;
 import org.apache.gobblin.util.ForkOperatorUtils;
+
+import com.google.common.base.Optional;
 
 
 /**
  * A {@link TimeBasedWriterPartitioner} for {@link GenericRecord}s.
  *
  * The {@link org.apache.avro.Schema.Field} that contains the timestamp can be specified using
- * {@link WRITER_PARTITION_COLUMNS}, and multiple values can be specified, e.g., "header.timestamp,device.timestamp".
+ * {@link TimeBasedAvroWriterPartitioner#WRITER_PARTITION_COLUMNS}, and multiple values can be specified, e.g., "header.timestamp,device.timestamp".
+ * The {@link TimeBasedAvroWriterPartitioner#WRITER_PARTITION_COLUMNS_PATTERN} that contains format of column when you have a date_time as string.
+ * format use {@link DateTimeFormatter} on default UTC, e.g., "yyyy-MM-dd HH:mm:ss:SSS"
+ * The {@link TimeBasedAvroWriterPartitioner#WRITER_PARTITION_COLUMNS_TIMEZONE} that contains timezone of column to convert date_time.
  *
  * If multiple values are specified, they will be tried in order. In the above example, if a record contains a valid
  * "header.timestamp" field, its value will be used, otherwise "device.timestamp" will be used.
+ *
  *
  * If a record contains none of the specified fields, or if no field is specified, the current timestamp will be used.
  */
 public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<GenericRecord> {
 
   public static final String WRITER_PARTITION_COLUMNS = ConfigurationKeys.WRITER_PREFIX + ".partition.columns";
+  public static final String WRITER_PARTITION_COLUMNS_PATTERN =
+      ConfigurationKeys.WRITER_PREFIX + ".partition.columns.pattern";
+  public static final String WRITER_PARTITION_COLUMNS_TIMEZONE =
+      ConfigurationKeys.WRITER_PREFIX + ".partition.columns.timezone";
+  private static final String UTC = "UTC";
 
   private final Optional<List<String>> partitionColumns;
+  private final Optional<String> partitionColumnPattern;
+  private final Optional<String> partitionColumnTimeZone;
+  private DateTimeFormatter partitionColumnDateTimeFormatter;
 
   public TimeBasedAvroWriterPartitioner(State state) {
     this(state, 1, 0);
@@ -53,11 +67,21 @@ public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<G
   public TimeBasedAvroWriterPartitioner(State state, int numBranches, int branchId) {
     super(state, numBranches, branchId);
     this.partitionColumns = getWriterPartitionColumns(state, numBranches, branchId);
+    this.partitionColumnPattern = getPropertyAsString(WRITER_PARTITION_COLUMNS_PATTERN, state, numBranches, branchId);
+    this.partitionColumnTimeZone = getPropertyAsString(WRITER_PARTITION_COLUMNS_TIMEZONE, state, numBranches, branchId);
+    if (this.partitionColumnPattern.isPresent()) {
+      this.partitionColumnDateTimeFormatter = DateTimeFormatter.ofPattern(partitionColumnPattern.get());
+    }
   }
 
   private static Optional<List<String>> getWriterPartitionColumns(State state, int numBranches, int branchId) {
     String propName = ForkOperatorUtils.getPropertyNameForBranch(WRITER_PARTITION_COLUMNS, numBranches, branchId);
-    return state.contains(propName) ? Optional.of(state.getPropAsList(propName)) : Optional.<List<String>> absent();
+    return state.contains(propName) ? Optional.of(state.getPropAsList(propName)) : Optional.<List<String>>absent();
+  }
+
+  private static Optional<String> getPropertyAsString(String property, State state, int numBranches, int branchId) {
+    String propName = ForkOperatorUtils.getPropertyNameForBranch(property, numBranches, branchId);
+    return state.contains(propName) ? Optional.of(state.getProp(propName)) : Optional.absent();
   }
 
   @Override
@@ -68,9 +92,19 @@ public class TimeBasedAvroWriterPartitioner extends TimeBasedWriterPartitioner<G
   /**
    *  Check if the partition column value is present and is a Long object. Otherwise, use current system time.
    */
-  private static long getRecordTimestamp(Optional<Object> writerPartitionColumnValue) {
-    return writerPartitionColumnValue.orNull() instanceof Long ? (Long) writerPartitionColumnValue.get()
-        : System.currentTimeMillis();
+  private long getRecordTimestamp(Optional<Object> writerPartitionColumnValue) {
+    long ret = System.currentTimeMillis();
+    if (!this.partitionColumnPattern.isPresent()) {
+      if (writerPartitionColumnValue.orNull() instanceof Long) {
+        ret = (Long) writerPartitionColumnValue.get();
+      }
+    } else {
+      if (writerPartitionColumnValue.orNull() instanceof String) {
+        ret = LocalDateTime.parse((String) writerPartitionColumnValue.get(), partitionColumnDateTimeFormatter)
+            .atZone(ZoneId.of(partitionColumnTimeZone.or(UTC))).toInstant().toEpochMilli();
+      }
+    }
+    return ret;
   }
 
   /**

--- a/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedORCSerDeWriterPartitioner.java
+++ b/gobblin-core/src/main/java/org/apache/gobblin/writer/partitioner/TimeBasedORCSerDeWriterPartitioner.java
@@ -17,13 +17,6 @@
 
 package org.apache.gobblin.writer.partitioner;
 
-import org.apache.gobblin.configuration.ConfigurationKeys;
-import org.apache.gobblin.configuration.State;
-import org.apache.gobblin.util.ForkOperatorUtils;
-import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -33,126 +26,140 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Optional;
 
+import org.apache.gobblin.configuration.ConfigurationKeys;
+import org.apache.gobblin.configuration.State;
+import org.apache.gobblin.util.ForkOperatorUtils;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
+
 
 /**
  * A {@link TimeBasedWriterPartitioner} for {@link OrcSerde.OrcSerdeRow}s.
- * <p>
+ *
  * The {@link OrcSerde.OrcSerdeRow} that contains the timestamp can be specified using
  * {@link TimeBasedORCSerDeWriterPartitioner#WRITER_PARTITION_COLUMN_NAME}.
  * only accept simple value, e.g., "timestamp" or "event_date".
  * The {@link TimeBasedORCSerDeWriterPartitioner#WRITER_PARTITION_COLUMN_INDEX} that contains the index of column, has better performance.
  * The {@link TimeBasedORCSerDeWriterPartitioner#WRITER_PARTITION_COLUMN_PATTERN} that contains format of column when you have a date_time as string.
- * All format use {@link DateTimeFormatter} on UTC, e.g., "yyyy-MM-dd HH:mm:ss:SSS"
- * <p>
+ * format use {@link DateTimeFormatter} on default UTC, e.g., "yyyy-MM-dd HH:mm:ss:SSS"
+ * The {@link TimeBasedORCSerDeWriterPartitioner#WRITER_PARTITION_COLUMN_TIMEZONE} that contains timezone of column to convert date_time.
+ *
+ *
  * If a record contains none of the specified fields, or if no field is specified, the current timestamp will be used.
  */
 public class TimeBasedORCSerDeWriterPartitioner extends TimeBasedWriterPartitioner<Object> {
 
-    private static final String WRITER_PARTITION_COLUMN_NAME = ConfigurationKeys.WRITER_PREFIX + ".partition.column";
-    private static final String WRITER_PARTITION_COLUMN_INDEX = ConfigurationKeys.WRITER_PREFIX + ".partition.column.index";
-    private static final String WRITER_PARTITION_COLUMN_PATTERN = ConfigurationKeys.WRITER_PREFIX + ".partition.column.pattern";
-    private static final String WRITER_PARTITION_COLUMN_TIMEZONE = ConfigurationKeys.WRITER_PREFIX + ".partition.column.timezone";
+  private static final String WRITER_PARTITION_COLUMN_NAME = ConfigurationKeys.WRITER_PREFIX + ".partition.column";
+  private static final String WRITER_PARTITION_COLUMN_INDEX =
+      ConfigurationKeys.WRITER_PREFIX + ".partition.column.index";
+  private static final String WRITER_PARTITION_COLUMN_PATTERN =
+      ConfigurationKeys.WRITER_PREFIX + ".partition.column.pattern";
+  private static final String WRITER_PARTITION_COLUMN_TIMEZONE =
+      ConfigurationKeys.WRITER_PREFIX + ".partition.column.timezone";
 
-    private static final String UTC = "UTC";
-    private static final String ORC_SERDE_INSPECTOR = "getInspector";
-    private static final String ORC_SERDE_ROW = "realRow";
+  private static final String UTC = "UTC";
+  private static final String ORC_SERDE_INSPECTOR = "getInspector";
+  private static final String ORC_SERDE_ROW = "realRow";
 
-    private final Optional<String> partitionColumnName;
-    private final Optional<Integer> partitionColumnIndex;
-    private final Optional<String> partitionColumnPattern;
-    private final Optional<String> partitionColumnTimeZone;
-    private DateTimeFormatter partitionColumnDateTimeFormatter;
+  private final Optional<String> partitionColumnName;
+  private final Optional<Integer> partitionColumnIndex;
+  private final Optional<String> partitionColumnPattern;
+  private final Optional<String> partitionColumnTimeZone;
+  private DateTimeFormatter partitionColumnDateTimeFormatter;
 
-    public TimeBasedORCSerDeWriterPartitioner(State state, int numBranches, int branchId) {
-        super(state, numBranches, branchId);
-        this.partitionColumnName = getPropertyAsString(WRITER_PARTITION_COLUMN_NAME, state, numBranches, branchId);
-        this.partitionColumnIndex = getPropertyAsInteger(WRITER_PARTITION_COLUMN_INDEX, state, numBranches, branchId);
-        this.partitionColumnPattern = getPropertyAsString(WRITER_PARTITION_COLUMN_PATTERN, state, numBranches, branchId);
-        this.partitionColumnTimeZone = getPropertyAsString(WRITER_PARTITION_COLUMN_TIMEZONE, state, numBranches, branchId);
-        if (this.partitionColumnPattern.isPresent()) {
-            this.partitionColumnDateTimeFormatter = DateTimeFormatter.ofPattern(partitionColumnPattern.get());
-        }
+  public TimeBasedORCSerDeWriterPartitioner(State state, int numBranches, int branchId) {
+    super(state, numBranches, branchId);
+    this.partitionColumnName = getPropertyAsString(WRITER_PARTITION_COLUMN_NAME, state, numBranches, branchId);
+    this.partitionColumnIndex = getPropertyAsInteger(WRITER_PARTITION_COLUMN_INDEX, state, numBranches, branchId);
+    this.partitionColumnPattern = getPropertyAsString(WRITER_PARTITION_COLUMN_PATTERN, state, numBranches, branchId);
+    this.partitionColumnTimeZone = getPropertyAsString(WRITER_PARTITION_COLUMN_TIMEZONE, state, numBranches, branchId);
+    if (this.partitionColumnPattern.isPresent()) {
+      this.partitionColumnDateTimeFormatter = DateTimeFormatter.ofPattern(partitionColumnPattern.get());
+    }
+  }
+
+  private static Optional<Integer> getPropertyAsInteger(String property, State state, int numBranches, int branchId) {
+    String propName = ForkOperatorUtils.getPropertyNameForBranch(property, numBranches, branchId);
+    return state.contains(propName) ? Optional.of(state.getPropAsInt(propName)) : Optional.empty();
+  }
+
+  private static Optional<String> getPropertyAsString(String property, State state, int numBranches, int branchId) {
+    String propName = ForkOperatorUtils.getPropertyNameForBranch(property, numBranches, branchId);
+    return state.contains(propName) ? Optional.of(state.getProp(propName)) : Optional.empty();
+  }
+
+  /**
+   * Check if the partition column value is present and is a Long object.
+   * if partitionColumnPattern is present we format LocalDateTime as EpochMilli.
+   * Otherwise, use current system time.
+   */
+  private long getRecordTimestamp(Optional<Object> writerPartitionColumnValue) {
+    long ret = System.currentTimeMillis();
+    if (!this.partitionColumnPattern.isPresent()) {
+      if (writerPartitionColumnValue.orElse(null) instanceof Long) {
+        ret = (Long) writerPartitionColumnValue.get();
+      }
+    } else {
+      if (writerPartitionColumnValue.orElse(null) instanceof String) {
+        ret = LocalDateTime.parse((String) writerPartitionColumnValue.get(), partitionColumnDateTimeFormatter)
+            .atZone(ZoneId.of(partitionColumnTimeZone.orElse(UTC))).toInstant().toEpochMilli();
+      }
+    }
+    return ret;
+  }
+
+  @Override
+  public long getRecordTimestamp(Object record) {
+    return getRecordTimestamp(getWriterPartitionColumnValue(record));
+  }
+
+  /**
+   * Retrieve the index of the partition column field specified by this.partitionColumnName. Is slowest performance.
+   */
+  private int extractTimestampIndex(Object orcRecord) {
+    if (!this.partitionColumnName.isPresent()) {
+      throw new IllegalArgumentException("writer.partition.column doesn't have value");
     }
 
-    private static Optional<Integer> getPropertyAsInteger(String property, State state, int numBranches, int branchId) {
-        String propName = ForkOperatorUtils.getPropertyNameForBranch(property, numBranches, branchId);
-        return state.contains(propName) ? Optional.of(state.getPropAsInt(propName)) : Optional.empty();
+    Class<?> clazz = orcRecord.getClass();
+    try {
+      Method method = clazz.getDeclaredMethod(ORC_SERDE_INSPECTOR);
+      method.setAccessible(true);
+      ObjectInspector inspector = (ObjectInspector) method.invoke(clazz.cast(orcRecord));
+      return ((StandardStructObjectInspector) inspector).getStructFieldRef(partitionColumnName.get()).getFieldID();
+    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+      throw new RuntimeException("writer.partition.column: " + partitionColumnName.get() + " doesn't exist on row");
+    }
+  }
+
+  /**
+   * Retrieve the value of the partition column field specified by this.partitionColumnIndex.
+   * If partitionColumnIndex not exist, this will seek it.
+   */
+  private Optional<Object> getWriterPartitionColumnValue(Object orcRecord) {
+    if (!this.partitionColumnName.isPresent()) {
+      return Optional.empty();
     }
 
-    private static Optional<String> getPropertyAsString(String property, State state, int numBranches, int branchId) {
-        String propName = ForkOperatorUtils.getPropertyNameForBranch(property, numBranches, branchId);
-        return state.contains(propName) ? Optional.of(state.getProp(propName)) : Optional.empty();
+    Class<?> clazz = orcRecord.getClass();
+    ArrayList<Object> realRow;
+
+    //only for check if column index is know.
+    int timestampIndex =
+        this.partitionColumnIndex.isPresent() ? this.partitionColumnIndex.get() : extractTimestampIndex(orcRecord);
+
+    try {
+      Field field = clazz.getDeclaredField(ORC_SERDE_ROW);
+      field.setAccessible(true);
+
+      realRow = (ArrayList<Object>) field.get(orcRecord);
+      if (realRow == null || realRow.size() <= timestampIndex) {
+        return Optional.empty();
+      }
+      return Optional.ofNullable(realRow.get(timestampIndex));
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
     }
-
-    /**
-     * Check if the partition column value is present and is a Long object.
-     * if partitionColumnPattern is present we format LocalDateTime as EpochMilli.
-     * Otherwise, use current system time.
-     */
-    private long getRecordTimestamp(Optional<Object> writerPartitionColumnValue) {
-        long ret = System.currentTimeMillis();
-        if (!this.partitionColumnPattern.isPresent()) {
-            if (writerPartitionColumnValue.orElse(null) instanceof Long)
-                ret = (Long) writerPartitionColumnValue.get();
-        } else {
-            if (writerPartitionColumnValue.orElse(null) instanceof String)
-                ret = LocalDateTime.parse((String) writerPartitionColumnValue.get(), partitionColumnDateTimeFormatter)
-                        .atZone(ZoneId.of(partitionColumnTimeZone.orElse(UTC))).toInstant().toEpochMilli();
-        }
-        return ret;
-    }
-
-    @Override
-    public long getRecordTimestamp(Object record) {
-        return getRecordTimestamp(getWriterPartitionColumnValue(record));
-    }
-
-    /**
-     * Retrieve the index of the partition column field specified by this.partitionColumnName. Is slowest performance.
-     */
-    private int extractTimestampIndex(Object orcRecord) {
-        if (!this.partitionColumnName.isPresent()) {
-            throw new IllegalArgumentException("writer.partition.column doesn't have value");
-        }
-
-        Class<?> clazz = orcRecord.getClass();
-        try {
-            Method method = clazz.getDeclaredMethod(ORC_SERDE_INSPECTOR);
-            method.setAccessible(true);
-            ObjectInspector inspector = (ObjectInspector) method.invoke(clazz.cast(orcRecord));
-            return ((StandardStructObjectInspector) inspector).getStructFieldRef(partitionColumnName.get()).getFieldID();
-        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-            throw new RuntimeException("writer.partition.column: " + partitionColumnName.get() + " doesn't exist on row");
-        }
-    }
-
-    /**
-     * Retrieve the value of the partition column field specified by this.partitionColumnIndex.
-     * If partitionColumnIndex not exist, this will seek it.
-     */
-    private Optional<Object> getWriterPartitionColumnValue(Object orcRecord) {
-        if (!this.partitionColumnName.isPresent()) {
-            return Optional.empty();
-        }
-
-        Class<?> clazz = orcRecord.getClass();
-        ArrayList<Object> realRow;
-
-        //only for check if column index is know.
-        int timestampIndex = this.partitionColumnIndex.isPresent() ?
-                this.partitionColumnIndex.get() : extractTimestampIndex(orcRecord);
-
-        try {
-            Field field = clazz.getDeclaredField(ORC_SERDE_ROW);
-            field.setAccessible(true);
-
-            realRow = (ArrayList<Object>) field.get(orcRecord);
-            if (realRow == null || realRow.size() <= timestampIndex) {
-                return Optional.empty();
-            }
-            return Optional.ofNullable(realRow.get(timestampIndex));
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
+  }
 }

--- a/gobblin-core/src/test/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitionerTest.java
+++ b/gobblin-core/src/test/java/org/apache/gobblin/writer/partitioner/TimeBasedAvroWriterPartitionerTest.java
@@ -24,13 +24,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.fs.Path;
-
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
 import org.apache.gobblin.configuration.ConfigurationKeys;
 import org.apache.gobblin.configuration.State;
 import org.apache.gobblin.stream.RecordEnvelope;
@@ -40,12 +33,17 @@ import org.apache.gobblin.writer.DataWriterBuilder;
 import org.apache.gobblin.writer.Destination;
 import org.apache.gobblin.writer.PartitionedDataWriter;
 import org.apache.gobblin.writer.WriterOutputFormat;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 
 /**
  * Tests for {@link TimeBasedAvroWriterPartitioner}.
  */
-@Test(groups = { "gobblin.writer.partitioner" })
+@Test(groups = {"gobblin.writer.partitioner"})
 public class TimeBasedAvroWriterPartitionerTest {
 
   private static final String SIMPLE_CLASS_NAME = TimeBasedAvroWriterPartitionerTest.class.getSimpleName();
@@ -56,17 +54,24 @@ public class TimeBasedAvroWriterPartitionerTest {
   private static final String BASE_FILE_PATH = "base";
   private static final String FILE_NAME = SIMPLE_CLASS_NAME + "-name.avro";
   private static final String PARTITION_COLUMN_NAME = "timestamp";
+  private static final String PARTITION_DATE_TIME_COLUMN_NAME = "date_time";
+  private static final String WRITER_PARTITION_COLUMNS_PATTERN = "yyyy-MM-dd HH:mm:ss";
+  private static final String WRITER_PARTITION_COLUMNS_TIMEZONE = "UTC";
   private static final String WRITER_ID = "writer-1";
 
   private static final String AVRO_SCHEMA =
-      "{" + "\"type\" : \"record\"," + "\"name\" : \"User\"," + "\"namespace\" : \"example.avro\"," + "\"fields\" : [ {"
-          + "\"name\" : \"" + PARTITION_COLUMN_NAME + "\"," + "\"type\" : \"long\"" + "} ]" + "}";
+      "{\"type\" : \"record\",\"name\" : \"User\",\"namespace\" : \"example.avro\",\"fields\" : " + "[ {\"name\" : \""
+          + PARTITION_COLUMN_NAME + "\",\"type\" : \"long\"}," + "{\"name\" : \"" + PARTITION_DATE_TIME_COLUMN_NAME
+          + "\",\"type\" : \"string\"} ]}";
 
   private Schema schema;
   private DataWriter<GenericRecord> writer;
+  private State properties;
+  private DataWriterBuilder<Schema, GenericRecord> builder;
 
   @BeforeClass
-  public void setUp() throws IOException {
+  public void setUp()
+      throws IOException {
     File stagingDir = new File(STAGING_DIR);
     File outputDir = new File(OUTPUT_DIR);
 
@@ -84,7 +89,7 @@ public class TimeBasedAvroWriterPartitionerTest {
 
     this.schema = new Schema.Parser().parse(AVRO_SCHEMA);
 
-    State properties = new State();
+    properties = new State();
     properties.setProp(TimeBasedAvroWriterPartitioner.WRITER_PARTITION_COLUMNS, PARTITION_COLUMN_NAME);
     properties.setProp(ConfigurationKeys.WRITER_BUFFER_SIZE, ConfigurationKeys.DEFAULT_BUFFER_SIZE);
     properties.setProp(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, ConfigurationKeys.LOCAL_FS_URI);
@@ -96,29 +101,17 @@ public class TimeBasedAvroWriterPartitionerTest {
     properties.setProp(ConfigurationKeys.WRITER_PARTITIONER_CLASS, TimeBasedAvroWriterPartitioner.class.getName());
 
     // Build a writer to write test records
-    DataWriterBuilder<Schema, GenericRecord> builder = new AvroDataWriterBuilder()
-        .writeTo(Destination.of(Destination.DestinationType.HDFS, properties)).writeInFormat(WriterOutputFormat.AVRO)
-        .withWriterId(WRITER_ID).withSchema(this.schema).withBranches(1).forBranch(0);
-    this.writer = new PartitionedDataWriter<Schema, GenericRecord>(builder, properties);
+    builder = new AvroDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+        .writeInFormat(WriterOutputFormat.AVRO).withWriterId(WRITER_ID).withSchema(this.schema).withBranches(1)
+        .forBranch(0);
   }
 
   @Test
-  public void testWriter() throws IOException {
+  public void testWriter()
+      throws IOException {
+    this.writer = new PartitionedDataWriter<>(builder, properties);
 
-    // Write three records, each should be written to a different file
-    GenericRecordBuilder genericRecordBuilder = new GenericRecordBuilder(this.schema);
-
-    // This timestamp corresponds to 2015/01/01
-    genericRecordBuilder.set("timestamp", 1420099200000l);
-    this.writer.writeEnvelope(new RecordEnvelope<>(genericRecordBuilder.build()));
-
-    // This timestamp corresponds to 2015/01/02
-    genericRecordBuilder.set("timestamp", 1420185600000l);
-    this.writer.writeEnvelope(new RecordEnvelope<>(genericRecordBuilder.build()));
-
-    // This timestamp corresponds to 2015/01/03
-    genericRecordBuilder.set("timestamp", 1420272000000l);
-    this.writer.writeEnvelope(new RecordEnvelope<>(genericRecordBuilder.build()));
+    this.writeRecords();
 
     // Check that the writer reports that 3 records have been written
     Assert.assertEquals(this.writer.recordsWritten(), 3);
@@ -126,8 +119,62 @@ public class TimeBasedAvroWriterPartitionerTest {
     this.writer.close();
     this.writer.commit();
 
+    assertFileCreations();
+  }
+
+  /**
+   * Write three records on writer.
+   * @throws IOException
+   */
+  private void writeRecords()
+      throws IOException {
+    // Write three records, each should be written to a different file
+    GenericRecordBuilder genericRecordBuilder = new GenericRecordBuilder(this.schema);
+
+    // This timestamp corresponds to 2015/01/01
+    genericRecordBuilder.set(PARTITION_COLUMN_NAME, 1420099200000l);
+    genericRecordBuilder.set(PARTITION_DATE_TIME_COLUMN_NAME, "2015-01-01 08:00:00");
+    this.writer.writeEnvelope(new RecordEnvelope<>(genericRecordBuilder.build()));
+
+    // This timestamp corresponds to 2015/01/02
+    genericRecordBuilder.set(PARTITION_COLUMN_NAME, 1420185600000l);
+    genericRecordBuilder.set(PARTITION_DATE_TIME_COLUMN_NAME, "2015-01-02 08:00:00");
+    this.writer.writeEnvelope(new RecordEnvelope<>(genericRecordBuilder.build()));
+
+    // This timestamp corresponds to 2015/01/03
+    genericRecordBuilder.set(PARTITION_COLUMN_NAME, 1420272000000l);
+    genericRecordBuilder.set(PARTITION_DATE_TIME_COLUMN_NAME, "2015-01-02 08:00:00");
+    this.writer.writeEnvelope(new RecordEnvelope<>(genericRecordBuilder.build()));
+  }
+
+  @Test
+  public void testWriterWithFormatter()
+      throws IOException {
+
+    properties
+        .setProp(TimeBasedAvroWriterPartitioner.WRITER_PARTITION_COLUMNS_PATTERN, WRITER_PARTITION_COLUMNS_PATTERN);
+    properties
+        .setProp(TimeBasedAvroWriterPartitioner.WRITER_PARTITION_COLUMNS_TIMEZONE, WRITER_PARTITION_COLUMNS_TIMEZONE);
+
+    this.writer = new PartitionedDataWriter<>(builder, properties);
+
+    this.writeRecords();
+
+    // Check that the writer reports that 3 records have been written
+    Assert.assertEquals(this.writer.recordsWritten(), 3);
+
+    this.writer.close();
+    this.writer.commit();
+
+    this.assertFileCreations();
+  }
+
+  /**
+   * Verify the creation of files for each partition.
+   */
+  private void assertFileCreations() {
     // Check that 3 files were created
-    Assert.assertEquals(FileUtils.listFiles(new File(TEST_ROOT_DIR), new String[] { "avro" }, true).size(), 3);
+    Assert.assertEquals(FileUtils.listFiles(new File(TEST_ROOT_DIR), new String[]{"avro"}, true).size(), 3);
 
     // Check if each file exists, and in the correct location
     File baseOutputDir = new File(OUTPUT_DIR, BASE_FILE_PATH);
@@ -147,7 +194,8 @@ public class TimeBasedAvroWriterPartitionerTest {
   }
 
   @AfterClass
-  public void tearDown() throws IOException {
+  public void tearDown()
+      throws IOException {
     this.writer.close();
     FileUtils.deleteDirectory(new File(TEST_ROOT_DIR));
   }


### PR DESCRIPTION
Fix TimeBasedORCSerDeWriterPartitioner format like goblin said.
Add suport ot date time strings on TimeBasedAvroWriterPartitioner.
writer.partition.columns.pattern that contains format of column
when you have a date_time as string that use DateTimeFormatter,
e.g., "yyyy-MM-dd HH:mm:ss:SSS"
writer.partition.columns.timezone that contains time zone to use
on DateTimeFormatter default UTC,
e.g., "GMT-3"

Example of new props:
writer.partition.columns.pattern=yyyy-MM-dd HH:mm:ss
writer.partition.columns.timezone=UTC

